### PR TITLE
Tab title on empty title

### DIFF
--- a/lib/tabs.js
+++ b/lib/tabs.js
@@ -276,7 +276,7 @@ var tabs = function(spec, my) {
         title = n.title;
       }
     });
-    return title;
+    return title || url_for_state(state);
   };
 
 


### PR DESCRIPTION
If there is no title specified or available, the url of the tab is now shown.
This happens for example when viewing raw files on github.
