### PR TITLE
Add transparency to tab loading bar

### DIFF
--- a/controls/strip/strip.css
+++ b/controls/strip/strip.css
@@ -155,7 +155,7 @@
   right: 0;
 
   z-index: 100;
-  opacity: 0;
+  opacity: 0.3;
 }
 
 .strip .tabs .tab.active > div.loading {


### PR DESCRIPTION
Add transparency of 0.3 to .strip .tabs .tab .loading so it is easier
to pick out tabs when they do not have focus.

TODO: Possibly move from hardcoded opacity levels to a user-config
file or dialog.

Author: jacobsmith

![breach_tabs_loading](https://cloud.githubusercontent.com/assets/3843162/3547301/4f7d0bd2-0894-11e4-85e8-05183073dfb9.png)
