### PR TITLE
Show tab color on hover.

### DIFF
--- a/controls/strip/strip.css
+++ b/controls/strip/strip.css
@@ -158,6 +158,10 @@
   opacity: 0;
 }
 
+.strip .tabs .tab:hover > div.loading {
+  opacity: 0.7;
+}
+
 .strip .tabs .tab.active > div.loading {
   opacity: 1.0;
 }


### PR DESCRIPTION
I know you made a decision to remove the color of inactive tabs, but feel it's important to have more visual distinction on the tab hover state than just showing the close icon.

This could again be done later with a module config system similar to the one mentioned in PR #20.
