### PR TITLE
Disabled user selection

### DIFF
--- a/controls/strip/strip.css
+++ b/controls/strip/strip.css
@@ -8,6 +8,7 @@
   padding: 0;
 
   overflow: hidden;
+  -webkit-user-select: none;
 }
 
 .strip .bottom {


### PR DESCRIPTION
By default, double clicking or Cmd/Ctrl+A selects element.
This CSS property disables user selection.
Fixes #22.

I've added this property to the `.strip`rule instead of `body`.
