### PR TITLE
fix for issue #21, cant click on filtered tab

### DIFF
--- a/controls/strip/strip_c.js
+++ b/controls/strip/strip_c.js
@@ -81,7 +81,7 @@ var strip_c = function(spec, my) {
     var tab = $('<div/>')
       .attr('id', tab_id)
       .addClass('tab')
-      .click(function(event) {
+      .mousedown(function(event) {
         switch(event.which) {
             case 1:
               select_tab(tab_id);


### PR DESCRIPTION
Fix for issue #21,
changed from click to mousedown, because since the elements are rearranged, the click always went to the previously selected tab.
