### PR TITLE
Disabled drop actions in strip

### DIFF
--- a/controls/box/index.html
+++ b/controls/box/index.html
@@ -12,6 +12,13 @@
     <link rel="stylesheet" href="box.css"/>
     <link rel="stylesheet" href="box.dark.css"/>
     <link rel="stylesheet" href="box.light.css"/>
+
+    <script src="/lib/jquery-2.1.1.min.js"></script>
+    <script type="text/javascript">
+      window.addEventListener("dragover",function(e){ e.preventDefault(); },false);
+      window.addEventListener("drop",function(e){ e.preventDefault(); },false);
+    </script>
+
   </head>
 
   <body>

--- a/controls/strip/index.html
+++ b/controls/strip/index.html
@@ -12,6 +12,12 @@
     <link rel="stylesheet" href="strip.css"/>
     <link rel="stylesheet" href="strip.dark.css"/>
     <link rel="stylesheet" href="strip.light.css"/>
+
+    <script src="/lib/jquery-2.1.1.min.js"></script>
+    <script type="text/javascript">
+      window.addEventListener("dragover",function(e){ e.preventDefault(); },false);
+      window.addEventListener("drop",function(e){ e.preventDefault(); },false);
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
Temporary fix for #32.
I think this is really a core issue: dropping on controls should never load the content in the control panel.
