### PR TITLE
Add the 'Open in new tab' when the context menu is created on a link.

### DIFF
--- a/lib/tabs.js
+++ b/lib/tabs.js
@@ -537,6 +537,16 @@ var tabs = function(spec, my) {
           });
           break;
         }
+        case 'Open in New Tab': {
+          breach.module('core').call('tabs_new', { 
+            url: my.context_menu_params.link_url,
+            visible: false,
+            focus: false,
+          }, function(err, res) {
+            if(err) { common.log.error('err'); }
+          }); 
+          break;
+        }
       }
     }
   };
@@ -561,6 +571,11 @@ var tabs = function(spec, my) {
       'Inspect Element',
       'Close DevTools'
     ];
+
+    // Add an entry if the click target contains a link
+    if(args.params.link_url.length > 0) {
+      items.splice(0, 0, 'Open in New Tab');
+    }
 
     var state = null;
     if(args.id === my.new_tab.tab_id) {


### PR DESCRIPTION
**_Requires:**_ breach/breach_core#179
Fixes #57.
