### PR TITLE
Added ability to add bars from other modules

### DIFF
--- a/controls/strip/index.html
+++ b/controls/strip/index.html
@@ -52,6 +52,8 @@
         </div>
       </div>
     </div>
+    <div class="bars">
+    </div>
 
     <!-- Scripts -->
     <script src="/socket.io/socket.io.js"></script>
@@ -65,7 +67,9 @@
 
     <!-- Main -->
     <script type="text/javascript">
-      var strip = strip_c({ strip_el: $('.strip') }).init();
+      var strip = strip_c({
+          strip_el: $('.strip'),
+          bars_el: $('.bars')}).init();
     </script>
   </body>
 </html>

--- a/controls/strip/strip.css
+++ b/controls/strip/strip.css
@@ -17,7 +17,6 @@
     top: 45px;
     right: 0;
     bottom: 0;
-    background-color: green;
 }
 
 .bar {

--- a/controls/strip/strip.css
+++ b/controls/strip/strip.css
@@ -11,6 +11,19 @@
   -webkit-user-select: none;
 }
 
+.bars {
+    position: absolute;
+    left: 0;
+    top: 45px;
+    right: 0;
+    bottom: 0;
+    background-color: green;
+}
+
+.bar {
+    width: 100%;
+}
+
 .strip .bottom {
   position: absolute;
   bottom: 0;

--- a/controls/strip/strip_c.js
+++ b/controls/strip/strip_c.js
@@ -6,14 +6,15 @@
  * @author: spolu
  *
  * @log:
- * - 2014-07-08 spolu  Disable actions when not available #11
- * - 2014-06-16 spolu  Tabs filtering
- * - 2014-06-13 spolu  Remove favicon on navigation #2
- * - 2014-06-13 spolu  Loading progress dumpling
- * - 2014-06-11 spolu  Removed angularJS
- * - 2014-06-04 spolu  Forked from `mod_stack`
- * - 2014-05-21 spolu  New state format (tabs on core_state)
- * - 2013-08-15 spolu  Creation
+ * - 2014-08-03 gammagec Added add_bar to insert external module bars under the strip
+ * - 2014-07-08 spolu    Disable actions when not available #11
+ * - 2014-06-16 spolu    Tabs filtering
+ * - 2014-06-13 spolu    Remove favicon on navigation #2
+ * - 2014-06-13 spolu    Loading progress dumpling
+ * - 2014-06-11 spolu    Removed angularJS
+ * - 2014-06-04 spolu    Forked from `mod_stack`
+ * - 2014-05-21 spolu    New state format (tabs on core_state)
+ * - 2013-08-15 spolu    Creation
  */
 'use strict'
 
@@ -39,8 +40,10 @@ var strip_c = function(spec, my) {
 
   /* Dictionary of tabs div elements. */
   my.tabs_divs = {};
-  my.bar_divs = {};
   my.active = null;
+
+  /* Dictionary of child bars attached underneath the strip. */
+  my.bar_divs = {};
 
   my.color = color({});
 
@@ -64,8 +67,7 @@ var strip_c = function(spec, my) {
   var update_tab;         /* update_tab(tab_id, data); */
   var position_tab;       /* update_tab(tab_id, idx); */
   var remove_tab;         /* update_tab(tab_id); */
-
-  var create_bar;
+  var create_bar;         /* create_bar(bar); */
 
   var mousewheel_handler; /* mousewheel_handler(evt); */
   var dblclick_handler;   /* dblclick_handler(evt); */
@@ -118,6 +120,12 @@ var strip_c = function(spec, my) {
     return tab;
   };
 
+  // ### create_bar
+  //
+  // Creates a new bar div element with the specified id.
+  // ```
+  // @bar {object} bar data.
+  // ```
   create_bar = function(bar) {
       var bar = $('<iframe/>')
           .attr('id', bar.id)
@@ -369,7 +377,6 @@ var strip_c = function(spec, my) {
   // ```
   state_handler = function(state) {
     if(state) {
-      console.log('state update ' + state.bars);
       var tabs_data = {};
       var tabs_order = [];
       /* Create any missing tab. */
@@ -382,7 +389,6 @@ var strip_c = function(spec, my) {
         }
       });
       if(state.bars) {
-          console.log(state.bars.length);
           state.bars.forEach(function (b) {
               if(!my.bar_divs[b.id]) {
                   my.bar_divs[b.id] = create_bar(b);

--- a/controls/strip/strip_c.js
+++ b/controls/strip/strip_c.js
@@ -28,6 +28,7 @@ var strip_c = function(spec, my) {
   spec = spec || {};
 
   my.strip_el = spec.strip_el || $('.strip');
+  my.bars_el = spec.bars_el || $('.bars');
   my.wrapper_el = my.strip_el.find('.wrapper');
   my.tabs_el = my.strip_el.find('.tabs');
   my.back_el = my.strip_el.find('.command.back');
@@ -38,6 +39,7 @@ var strip_c = function(spec, my) {
 
   /* Dictionary of tabs div elements. */
   my.tabs_divs = {};
+  my.bar_divs = {};
   my.active = null;
 
   my.color = color({});
@@ -62,6 +64,8 @@ var strip_c = function(spec, my) {
   var update_tab;         /* update_tab(tab_id, data); */
   var position_tab;       /* update_tab(tab_id, idx); */
   var remove_tab;         /* update_tab(tab_id); */
+
+  var create_bar;
 
   var mousewheel_handler; /* mousewheel_handler(evt); */
   var dblclick_handler;   /* dblclick_handler(evt); */
@@ -113,6 +117,17 @@ var strip_c = function(spec, my) {
           .addClass('icon-iconfont-01')));
     return tab;
   };
+
+  create_bar = function(bar) {
+      var bar = $('<iframe/>')
+          .attr('id', bar.id)
+          .attr('height', bar.dimension)
+          .attr('frameborder', 0)
+          .attr('scrolling', 'no')
+          .addClass('bar')
+          .attr('src', bar.url);
+      return bar;
+  }
 
   // ### update_tab
   //
@@ -354,6 +369,7 @@ var strip_c = function(spec, my) {
   // ```
   state_handler = function(state) {
     if(state) {
+      console.log('state update ' + state.bars);
       var tabs_data = {};
       var tabs_order = [];
       /* Create any missing tab. */
@@ -365,6 +381,15 @@ var strip_c = function(spec, my) {
           my.strip_el.find('.tabs').append(my.tabs_divs[t.tab_id]);
         }
       });
+      if(state.bars) {
+          console.log(state.bars.length);
+          state.bars.forEach(function (b) {
+              if(!my.bar_divs[b.id]) {
+                  my.bar_divs[b.id] = create_bar(b);
+                  my.bars_el.append(my.bar_divs[b.id]);
+              }
+          });
+      }
       /* Cleanup Closed tabs */
       Object.keys(my.tabs_divs).forEach(function(tab_id) {
         if(!tabs_data[tab_id]) {

--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@
  * @author: spolu
  *
  * @log:
- * - 2014-07-22 spolu   Fix DNS error when not connected
- * - 2014-06-04 spolu   Move to `mod_layout`
- * - 2014-01-17 spolu   Creation
+ * - 2014-08-03 gammagec Added add_bar method to add external modules under the strip
+ * - 2014-07-22 spolu    Fix DNS error when not connected
+ * - 2014-06-04 spolu    Move to `mod_layout`
+ * - 2014-01-17 spolu    Creation
  */
 "use strict"
 
@@ -75,8 +76,7 @@ var bootstrap = function(http_srv) {
     });
 
     breach.expose('add_bar', function(src, args, cb_) {
-       console.log("adding bar ", args.url + ':' + args.dimension);
-       common._.strip.addBar(args, cb_);
+       common._.strip.add_bar(args.id, args.url, args.dimension, cb_);
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -73,6 +73,11 @@ var bootstrap = function(http_srv) {
         common.exit(0);
       });
     });
+
+    breach.expose('add_bar', function(src, args, cb_) {
+       console.log("adding bar ", args.url + ':' + args.dimension);
+       common._.strip.addBar(args, cb_);
+    });
   });
 
   var io = require('socket.io').listen(http_srv, {

--- a/lib/strip.js
+++ b/lib/strip.js
@@ -6,9 +6,10 @@
  * @author: spolu
  *
  * @log:
- * - 2014-06-16 spolu  Tabs filtering
- * - 2014-06-16 spolu  Removed action_next/prev towards tabs filtering
- * - 2014-06-04 spolu  Creation
+ * - 2014-08-03 gammagec Added ability to insert external module bars under the strip
+ * - 2014-06-16 spolu    Tabs filtering
+ * - 2014-06-16 spolu    Removed action_next/prev towards tabs filtering
+ * - 2014-06-04 spolu    Creation
  */
 "use strict"
 
@@ -46,8 +47,7 @@ var strip = function(spec, my) {
   var handshake;                    /* handshake(socket) */
   var init;                         /* init(cb_); */
   var kill;                         /* kill(cb_); */
-
-  var addBar;
+  var add_bar;                      /* add_bar(id, url, dimension, cb_); */
 
   //
   // ### _private_
@@ -506,25 +506,39 @@ var strip = function(spec, my) {
     }, cb_);
   };
 
-  addBar = function(args, cb_) {
-      var height = args.dimension;
-      console.log('strip adding bar ' + args.url + ' ' + height);
+  // ### add_bar
+  //
+  // Adds an iframe for an external module to put new bars underneath the strip.
+  // ```
+  // @id {string} information about the bar to add.
+  // @url {string}
+  // @dimension {number}
+  // @cb_ {function(err)} the async callback.
+  // ```
+  add_bar = function(id, url, dimension, cb_) {
 
+      // check if bar with id already exists
       var found = false;
       my.bars.forEach(function(b) {
-          if (b.id === args.id) {
+          if (b.id === id) {
             found = true;
           }
       });
+      // don't do anything if bar with id already exists
       if(found) return cb_();
 
-      my.bars.push(args);
+      // insert the new bar to the state
+      my.bars.push({ id: id, url: url, dimension: dimension });
+      // push state change to UI
       socket_push();
+
       var total_height = 45;
+      // calculate the new strip height
       my.bars.forEach(function(b) {
           total_height += b.dimension;
       });
       async.series([
+          // reset the height of the strip bar.
           function(cb_) {
               breach.module('core').call('controls_dimension', {
                   type: 'TOP',
@@ -537,7 +551,7 @@ var strip = function(spec, my) {
 
   common.method(that, 'init', init, _super);
   common.method(that, 'kill', kill, _super);
-  common.method(that, 'addBar', addBar, _super);
+  common.method(that, 'add_bar', add_bar, _super);
 
   common.method(that, 'handshake', handshake, _super);
 

--- a/lib/strip.js
+++ b/lib/strip.js
@@ -38,12 +38,16 @@ var strip = function(spec, my) {
   my.breach_update = false;
   my.module_update = false;
 
+  my.bars = [];
+
   //
   // ### _public_
   //
   var handshake;                    /* handshake(socket) */
   var init;                         /* init(cb_); */
   var kill;                         /* kill(cb_); */
+
+  var addBar;
 
   //
   // ### _private_
@@ -96,6 +100,7 @@ var strip = function(spec, my) {
     var state = {
       active: -1,
       tabs: [],
+      bars: [],
       breach_update: my.breach_update,
       module_update: my.module_update
     };
@@ -113,6 +118,9 @@ var strip = function(spec, my) {
         }
         return false;
       });
+    }
+    if(my.bars) {
+        state.bars = my.bars;
     }
     return state;
   };
@@ -498,9 +506,38 @@ var strip = function(spec, my) {
     }, cb_);
   };
 
+  addBar = function(args, cb_) {
+      var height = args.dimension;
+      console.log('strip adding bar ' + args.url + ' ' + height);
+
+      var found = false;
+      my.bars.forEach(function(b) {
+          if (b.id === args.id) {
+            found = true;
+          }
+      });
+      if(found) return cb_();
+
+      my.bars.push(args);
+      socket_push();
+      var total_height = 45;
+      my.bars.forEach(function(b) {
+          total_height += b.dimension;
+      });
+      async.series([
+          function(cb_) {
+              breach.module('core').call('controls_dimension', {
+                  type: 'TOP',
+                  dimension: total_height
+              }, cb_);
+          }
+      ], cb_);
+  }
+
 
   common.method(that, 'init', init, _super);
   common.method(that, 'kill', kill, _super);
+  common.method(that, 'addBar', addBar, _super);
 
   common.method(that, 'handshake', handshake, _super);
 


### PR DESCRIPTION
I have added the ability to call  breach.module('mod_strip').call('add_bar', {
                        url: 'http://localhost:' + port + '/bar',
                        dimension: 45,
                        id: 'bookmarks'
                    }, cb_);

Which increases the height of the mod_strip strip bar and inserts an iframe with the new module underneath it.  This can be done multiple times to add multiple other bars underneath the strip bar.
