### PR TITLE
Update box.dark.css

### DIFF
--- a/controls/box/box.dark.css
+++ b/controls/box/box.dark.css
@@ -1,6 +1,9 @@
 .box.dark .ssl {
   color: hsl(0, 0%, 15%);
 }
+.box.dark .search {
+  color: hsl(0, 100%, 100%);
+}
 
 .box.dark .input .shadow {
   background-color: hsl(0, 0%, 10%);


### PR DESCRIPTION
Changes color for the search icon to white when dark theme is enabled.

![breach-dark-box](https://cloud.githubusercontent.com/assets/506932/3788351/75fa8504-1a60-11e4-874c-904790487f1d.png)
