### PR TITLE
Update box.dark.css

### DIFF
--- a/controls/box/box.dark.css
+++ b/controls/box/box.dark.css
@@ -1,5 +1,8 @@
 .box.dark .ssl {
-  color: hsl(0, 0%, 15%);
+  color: hsl(0, 0%, 80%);
+}
+.box.dark .search {
+  color: hsl(0, 0%, 95%);
 }
 
 .box.dark .input .shadow {


### PR DESCRIPTION
Changes color for the search icon & SSL icon to white when dark theme is enabled.

![breach-dark-box](https://cloud.githubusercontent.com/assets/506932/3788351/75fa8504-1a60-11e4-874c-904790487f1d.png)
